### PR TITLE
Updated AVR board package to 1.0.1

### DIFF
--- a/IDE_Board_Manager/package_sparkfun_index.json
+++ b/IDE_Board_Manager/package_sparkfun_index.json
@@ -1,52 +1,53 @@
 {
    "packages":[
-      {
-         "name":"SparkFun",
-         "maintainer":"SparkFun Electronics",
-         "websiteURL":"https://SparkFun.com",
-         "email":"TechSupport@SparkFun.com",
-         "help":{
-            "online":"https://forum.sparkfun.com"
-         },
-         "platforms":[
-            {
-               "name":"SparkFun AVR Boards",
-               "architecture":"avr",
-               "version":"1.0.0",
-               "category":"Contributed",
-               "url":"https://github.com/sparkfun/Arduino_Boards/raw/master/IDE_Board_Manager/sparkfunboards.tar.bz2",
-               "archiveFileName":"sparkfunboards.tar.bz2",
-               "checksum":"SHA-256:e7c98943126f250a55bb59f11704552ed5d47f8b582b5bb9b4e3d940ec2d6919",
-               "size":"819686",
-               "help":{
-                  "online":"https://forums.sparkfun.com"
-               },
-               "boards":[
-                  { "name":"ATmega128RFA1 Dev Board" },
-                  { "name":"Digital Sandbox" },
-                  { "name":"Fio V3 3.3V / 8MHz" },
-                  { "name":"MaKey MaKey" },
-                  { "name":"Mega Pro Mini 3.3V / 8MHz" },
-                  { "name":"ProMicro 3.3V / 8MHz" },
-                  { "name":"ProMicro 5V / 16MHz" },
-                  { "name":"Serial 7-segment Display" }
-               ],
-               "toolsDependencies":[
-                  {
-                     "packager":"arduino",
-                     "name":"avr-gcc",
-                     "version":"4.8.1-arduino5"
-                  },
-                  {
-                     "packager":"arduino",
-                     "name":"avrdude",
-                     "version":"6.0.1-arduino5"
-                  }
-               ]
-            }
-         ],
-         "tools":[]
-      },
+     {
+        "name":"SparkFun",
+        "maintainer":"SparkFun Electronics",
+        "websiteURL":"https://SparkFun.com",
+        "email":"TechSupport@SparkFun.com",
+        "help":{
+           "online":"https://forum.sparkfun.com"
+        },
+        "platforms":[
+           {
+              "name":"SparkFun AVR Boards",
+              "architecture":"avr",
+              "version":"1.0.1",
+              "category":"Contributed",
+              "url":"https://github.com/sparkfun/Arduino_Boards/raw/master/IDE_Board_Manager/sparkfunboards.tar.bz2",
+              "archiveFileName":"sparkfunboards.tar.bz2",
+              "checksum":"SHA-256:be06eaf398931b03de7446ac5c8e40035be52d49a12cb240d09e6e2e42f6c9e3",
+              "size":"817537",
+              "help":{
+                 "online":"https://forums.sparkfun.com"
+              },
+              "boards":[
+                 { "name":"RedBoard" },
+                 { "name":"MaKey MaKey" },
+                 { "name":"Pro Micro" },
+                 { "name":"Fio v3" },
+                 { "name":"Digital Sandbox" },
+                 { "name":"Mega Pro" },
+                 { "name":"RedBot" },
+                 { "name":"Serial 7-segment Display" },
+                 { "name":"ATmega128RFA1 Dev Board" }
+              ],
+              "toolsDependencies":[
+                 {
+                    "packager":"arduino",
+                    "name":"avr-gcc",
+                    "version":"4.8.1-arduino5"
+                 },
+                 {
+                    "packager":"arduino",
+                    "name":"avrdude",
+                    "version":"6.0.1-arduino5"
+                 }
+              ]
+           }
+        ],
+        "tools":[]
+     },
 	{
 		"name":"SparkFun",
 		"maintainer":"SparkFun Electroncs",
@@ -67,11 +68,11 @@
 			"help":{
 				"online":"https://learn.sparkfun.com"
 			},
-			"boards":[ 
+			"boards":[
 				{ "name":"Generic ESP8266 Module" },
 				{ "name":"SparkFun ESP8266 Thing" }
 			],
-			"toolsDependencies":[ 
+			"toolsDependencies":[
 			{
 				"packager":"SparkFun",
 				"name":"esptool",
@@ -81,10 +82,10 @@
 				"packager":"SparkFun",
 				"name":"xtensa-lx106-elf-gcc",
 				"version":"1.20.0-26-gb404fb9"
-			} 
+			}
 			]
 		} ],
-		"tools": [ 
+		"tools": [
 		{
 			"name":"esptool",
 			"version":"0.4.4",
@@ -115,7 +116,7 @@
 				"url":"https://github.com/igrr/esptool-ck/releases/download/0.4.4/esptool-0.4.4-linux32.tar.gz",
 				"archiveFileName":"esptool-0.4.4-linux32.tar.gz",
 				"checksum":"SHA-256:4aa81b97a470641771cf371e5d470ac92d3b177adbe8263c4aae66e607b67755",
-				"size":"12044"	
+				"size":"12044"
 			}
 			]
 		},
@@ -152,7 +153,7 @@
 				"size":"32734156"
 			}
 			]
-		} 
+		}
 		]
 	}
    ]


### PR DESCRIPTION
The current version of the AVR board definitions in the ESP8266 package are out of date, causing a CRC error when attempting to install the package via the Arduino 1.6.x board manager.

It would be ideal to merge the two board package JSON files, or completely split the AVR and ESP8266 board packages into their own JSON files. The Arduino IDE will not load the separate definitions from the two JSON files as things currently stand. If both JSON files are included in the boards manager URL list, one will override the other. There's no way to get both packages installed correctly without some painful workarounds by the end user.