### PR TITLE
change inconsistent 'online help' links

### DIFF
--- a/IDE_Board_Manager/package_sparkfun_index.json
+++ b/IDE_Board_Manager/package_sparkfun_index.json
@@ -6,7 +6,7 @@
       "websiteURL": "https://SparkFun.com",
       "email": "TechSupport@SparkFun.com",
       "help": {
-        "online": "https://forum.sparkfun.com"
+        "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
       },
       "platforms": [
         {
@@ -19,7 +19,7 @@
           "checksum": "SHA-256:41f9728983e0dbab597bb46ddf00b5bac6cfec7c8f3771ecd1612dae58bb0366",
           "size": "1162215",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -65,7 +65,7 @@
           "checksum": "SHA-256:049FA0DF51602120EC1BDAC19F440FC0CC448C23BB277DD0D8DF855C52ACD483",
           "size": "1159276",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -111,7 +111,7 @@
           "checksum": "SHA-256:16A9CA03A7869C424562795504B82FEED0FB6A7D4A63FC94280FBBA44132257C",
           "size": "1236343",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -160,7 +160,7 @@
           "checksum": "SHA-256:23D479AF10DC97F4DB8EA8AD514FE92C4391EADD8D9DD5EF1D49A70EA05255C3",
           "size": "1238017",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -209,7 +209,7 @@
           "checksum": "SHA-256:89480C355876966DB68504E4E4130719942320AECF0AD6AEF819299796B22202",
           "size": "1238253",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -258,7 +258,7 @@
           "checksum": "SHA-256:ABC30EF048B0BE63B6E3BB02A1FD52F35E2FC4A1CAFD60D4E7C3F9FD776129C0",
           "size": "1237620",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -307,7 +307,7 @@
           "checksum": "SHA-256:12e0be6862a3a28b6515755dcad2842757caf4e5270326554f95059512ebaab5",
           "size": "268954",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -329,7 +329,7 @@
           "checksum": "SHA-256:5d71cbf8ccf5781eef9809d7b3141041daf3ed1a1272f5278762ece5a0aecf44",
           "size": "279683",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -351,7 +351,7 @@
           "checksum": "SHA-256:50e055f311e07ba4d154bf00aa10579648024bef680bb3eb267401c496f791e6",
           "size": "281932",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -373,7 +373,7 @@
           "checksum": "SHA-256:63b90fb26a18a89b2f51556a08286117cdade38d6cb7a16eb1eccb7d1d92422a",
           "size": "280405",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -395,7 +395,7 @@
           "checksum": "SHA-256:21bc1ab1a8fd6550dca3b4953deaa2066d49ffa2583cd8e8a1e36d0c0ab00d52",
           "size": "283240",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -417,7 +417,7 @@
           "checksum": "SHA-256:87695137f303000099e7e6d3fae3e87d5882ed999e4c14403c65cf51a4d6a6be",
           "size": "195440",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -442,7 +442,7 @@
           "checksum": "SHA-256:eb4274a3df4c6c4dbc1396600b1efc9cd9454e5be4880530ff87ba4fb3e6216a",
           "size": "206253",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {
@@ -467,7 +467,7 @@
           "checksum": "SHA-256:968918117E6EA9C7F3982F83E07B6459663AB844779855B5E175E19461C16691",
           "size": "289555",
           "help": {
-            "online": "https://forums.sparkfun.com"
+            "online": "https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager"
           },
           "boards": [
             {


### PR DESCRIPTION
Some were 'forum', some were 'forums'. The latter exists but fails, even though it's just a CNAME to the former. It seems like 'online help' should go to help, so I pointed it [here](https://learn.sparkfun.com/tutorials/installing-arduino-ide/board-add-ons-with-arduino-board-manager). Another option would be to use the arduino forum](https://forum.sparkfun.com/viewforum.php?f=32), but .. the forums aren't exactly super-active. [This page](https://learn.sparkfun.com/pages/CustomBoardsArduino) is an option too. It has a good URL, though imperfect text I think.

Verified with `jsonlint` 1.6.0 for node to make sure I hadn't broken anything.

Feel free to send me one of every product as a thank-you.