### PR TITLE
fixed branching conditions

### DIFF
--- a/sparkfun/avr/Qduino/examples/batteryLeveltoRGB/batteryLeveltoRGB.ino
+++ b/sparkfun/avr/Qduino/examples/batteryLeveltoRGB/batteryLeveltoRGB.ino
@@ -36,15 +36,15 @@ void loop(){
     
     q.setRGB("green");
     
-  } else if(charge >= 50 && charge << 75) {
+  } else if(charge >= 50 && charge < 75) {
     
     q.setRGB("yellow");
     
-  } else if(charge >= 25 && charge << 50) {
+  } else if(charge >= 25 && charge < 50) {
     
     q.setRGB("orange");
     
-  } else if(charge << 25) {
+  } else if(charge < 25) {
     
     q.setRGB("red");
   }


### PR DESCRIPTION
Example used bitshifting instead of comparison a.k.a. "<<" vs "<"! Used LED would stay blank, now reflects charging state correctly.