### PR TITLE
Add SPI clock divider support for 120MHz SAMD boards.

### DIFF
--- a/sparkfun/samd/libraries/SPI/SPI.h
+++ b/sparkfun/samd/libraries/SPI/SPI.h
@@ -163,6 +163,16 @@ class SPIClass {
   #define SPI_CLOCK_DIV32  96
   #define SPI_CLOCK_DIV64  192
   #define SPI_CLOCK_DIV128 255
-#endif
+#endif /* F_CPU == 48000000 */
+#if F_CPU == 120000000
+  #define SPI_CLOCK_DIV2   15
+  #define SPI_CLOCK_DIV4   30
+  #define SPI_CLOCK_DIV8   60
+  #define SPI_CLOCK_DIV16  120
+  #define SPI_CLOCK_DIV32  240
+  #define SPI_CLOCK_DIV64  480
+  #define SPI_CLOCK_DIV128 960
+#endif /* F_CPU == 120000000 */
+
 
 #endif


### PR DESCRIPTION
Hello!

I ran into [an issue](https://github.com/sparkfun/SparkFun_BME280_Arduino_Library/issues/38) with the BME280 library on the SAMD51 Thing Plus; I think this is the appropriate fix and will likely fix other SPI-related bugs in other libraries.

Another option would be to define the SPI clock dividers e.g.

```
  #define SPI_CLOCK_DIV2  ((F_CPU / 16000000) * 2)
```

to support faster boards in the future.

Cheers!