### PR TITLE
SAMD51 I2C slave support for Wire library and SAMD51 Thing Plus

### DIFF
--- a/sparkfun/samd/libraries/Wire/Wire.cpp
+++ b/sparkfun/samd/libraries/Wire/Wire.cpp
@@ -287,6 +287,13 @@ void TwoWire::onService(void)
   void WIRE_IT_HANDLER(void) {
     Wire.onService();
   }
+
+  #if defined(__SAMD51__)
+    void WIRE_IT_HANDLER_0(void) { Wire.onService(); }
+    void WIRE_IT_HANDLER_1(void) { Wire.onService(); }
+    void WIRE_IT_HANDLER_2(void) { Wire.onService(); }
+    void WIRE_IT_HANDLER_3(void) { Wire.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 1
@@ -295,6 +302,13 @@ void TwoWire::onService(void)
   void WIRE1_IT_HANDLER(void) {
     Wire1.onService();
   }
+
+  #if defined(__SAMD51__)
+    void WIRE1_IT_HANDLER_0(void) { Wire1.onService(); }
+    void WIRE1_IT_HANDLER_1(void) { Wire1.onService(); }
+    void WIRE1_IT_HANDLER_2(void) { Wire1.onService(); }
+    void WIRE1_IT_HANDLER_3(void) { Wire1.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 2
@@ -303,6 +317,13 @@ void TwoWire::onService(void)
   void WIRE2_IT_HANDLER(void) {
     Wire2.onService();
   }
+
+  #if defined(__SAMD51__)
+    void WIRE2_IT_HANDLER_0(void) { Wire2.onService(); }
+    void WIRE2_IT_HANDLER_1(void) { Wire2.onService(); }
+    void WIRE2_IT_HANDLER_2(void) { Wire2.onService(); }
+    void WIRE2_IT_HANDLER_3(void) { Wire2.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 3
@@ -311,6 +332,13 @@ void TwoWire::onService(void)
   void WIRE3_IT_HANDLER(void) {
     Wire3.onService();
   }
+
+  #if defined(__SAMD51__)
+    void WIRE3_IT_HANDLER_0(void) { Wire3.onService(); }
+    void WIRE3_IT_HANDLER_1(void) { Wire3.onService(); }
+    void WIRE3_IT_HANDLER_2(void) { Wire3.onService(); }
+    void WIRE3_IT_HANDLER_3(void) { Wire3.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 4
@@ -319,6 +347,13 @@ void TwoWire::onService(void)
   void WIRE4_IT_HANDLER(void) {
     Wire4.onService();
   }
+
+  #if defined(__SAMD51__)
+    void WIRE4_IT_HANDLER_0(void) { Wire4.onService(); }
+    void WIRE4_IT_HANDLER_1(void) { Wire4.onService(); }
+    void WIRE4_IT_HANDLER_2(void) { Wire4.onService(); }
+    void WIRE4_IT_HANDLER_3(void) { Wire4.onService(); }
+  #endif // __SAMD51__
 #endif
 
 #if WIRE_INTERFACES_COUNT > 5
@@ -327,5 +362,12 @@ void TwoWire::onService(void)
   void WIRE5_IT_HANDLER(void) {
     Wire5.onService();
   }
+
+  #if defined(__SAMD51__)
+    void WIRE5_IT_HANDLER_0(void) { Wire5.onService(); }
+    void WIRE5_IT_HANDLER_1(void) { Wire5.onService(); }
+    void WIRE5_IT_HANDLER_2(void) { Wire5.onService(); }
+    void WIRE5_IT_HANDLER_3(void) { Wire5.onService(); }
+  #endif // __SAMD51__
 #endif
 

--- a/sparkfun/samd/variants/SparkFun_SAMD51_Thing_Plus/variant.h
+++ b/sparkfun/samd/variants/SparkFun_SAMD51_Thing_Plus/variant.h
@@ -166,6 +166,10 @@ static const uint8_t FLASH_SCK  = PIN_SPI1_SCK ;
 #define PIN_WIRE_SCL         (21u)
 #define PERIPH_WIRE          sercom3
 #define WIRE_IT_HANDLER      SERCOM3_Handler
+#define WIRE_IT_HANDLER_0    SERCOM3_0_Handler
+#define WIRE_IT_HANDLER_1    SERCOM3_1_Handler
+#define WIRE_IT_HANDLER_2    SERCOM3_2_Handler
+#define WIRE_IT_HANDLER_3    SERCOM3_3_Handler
 
 static const uint8_t SDA = PIN_WIRE_SDA;
 static const uint8_t SCL = PIN_WIRE_SCL;


### PR DESCRIPTION
Fixes #56 by adding handlers for all for SAMD51 SERCOM I2C interrupts to `wire.cpp` and defining them in the Thing Plus' `variant.h`.