### PR TITLE
added package_sparkfun_index.json entry for aarch64 Support

### DIFF
--- a/IDE_Board_Manager/package_sparkfun_index.json
+++ b/IDE_Board_Manager/package_sparkfun_index.json
@@ -1358,7 +1358,14 @@
               "checksum": "SHA-256:fb31fbdfe08406ece43eef5df623c0b2deb8b53e405e2c878300f7a1f303ee52", 
               "archiveFileName": "gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2", 
               "size": "107253352"
-            }, 
+            },
+	    { 
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
+              "checksum": "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76",
+              "size": "99558726"
+            },
             {
               "host": "i686-mingw32",
               "url": "https://static.sparkfun.com/large/gcc-arm-none-eabi-8-2018-q4-major-win32-modified.zip", 


### PR DESCRIPTION
In reference to <a href="https://github.com/sparkfun/Arduino_Apollo3/issues/105">Apollo3 Core Issue #105</a>:

I was having issues getting my arduino code to compile on my Jetson Nano. Adding 

```
            {
              "host": "aarch64-linux-gnu",
              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
              "checksum": "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76",
              "size": "99558726"
            },
```
to the package index .json file allowed my code to compile.