### PR TITLE
changes to package_name and contact email for esp8266 package

### DIFF
--- a/IDE_Board_Manager/package_sparkfun_index.json
+++ b/IDE_Board_Manager/package_sparkfun_index.json
@@ -2119,8 +2119,8 @@
           ]
         }
       ],
-      "email": "ivan@esp8266.com",
-      "name": "esp8266"
+      "email": "TechSupport@SparkFun.com",
+      "name": "Sparkfun"
     }
   ]
 }


### PR DESCRIPTION
dear Sparkfun
we had some issues while using our CLI when both your boards definitions and Espressif's platforms were installed.
I investigated and found out that there was an overlap in package name between yours and Espressif's.
Applying this change removes all conflicts and the available platforms for install are correctly displayed when an Arduino CLI user (or workflow) issues a `arduino-cli core search esp8266`

```
Sparkfun:esp8266 2.1.2   SparkFun ESP8266 Boards
esp8266:esp8266  2.7.4   esp8266
```

before only the one maintained by Espressif would show.
Hope you'll want to consider this PR

thank you
ubi de feo
Arduino Tooling Team