### PR TITLE
Define custom cache menu title for SAMD51 boards

### DIFF
--- a/sparkfun/samd/boards.txt
+++ b/sparkfun/samd/boards.txt
@@ -14,6 +14,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+menu.cache=Cache
+
 samd21_dev.name=SparkFun SAMD21 Dev Breakout
 samd21_dev.vid.0=0x1B4F
 samd21_dev.pid.0=0x8D21


### PR DESCRIPTION
The "SparkFun SAMD51 MicroMod" and "SparkFun SAMD51 Thing Plus" boards have a custom "cache" board option that controls flash caching:
https://learn.adafruit.com/adafruit-grand-central/adapting-sketches-to-m0#cache-3026398-25

From the Arduino platform specification:
https://arduino.github.io/arduino-cli/latest/platform-specification/#custom-board-options

> We must first define a set of menu.MENU_ID=Text properties. Text is what is displayed on the GUI for every custom menu
> we are going to create and must be declared at the beginning of the boards.txt file:

This `menu.cache` property was missing (I guess it was not transferred over from Adafruit SAMD Boards):
https://github.com/adafruit/ArduinoCore-samd/blob/1.6.5/boards.txt#L17

This resulted in the option not being controllable via a **Tools > Cache** menu in the Arduino IDE, as is normally the case
for custom board options. More significant, it breaks [Arduino IDE 2.x](https://github.com/arduino/arduino-ide) (which is more strict about specification-compliance) when one of those boards is selected.

![Clipboard01](https://user-images.githubusercontent.com/8572152/108608769-0f052100-737e-11eb-8f2c-b48bbb9e3961.png)
