### PR TITLE
Upgrade ESP32 Tools

### DIFF
--- a/IDE_Board_Manager/package_sparkfun_index.json
+++ b/IDE_Board_Manager/package_sparkfun_index.json
@@ -843,12 +843,12 @@
           "toolsDependencies": [
             {
               "packager": "esp32", 
-              "version": "1.22.0-80-g6c4433a-5.2.0", 
+              "version": "1.22.0-97-gc752ad5-5.2.0", 
               "name": "xtensa-esp32-elf-gcc"
             }, 
             {
               "packager": "esp32", 
-              "version": "2.6.1", 
+              "version": "3.0.0", 
               "name": "esptool_py"
             }, 
             {


### PR DESCRIPTION
Upstream [ESP32 tools](https://dl.espressif.com/dl/package_esp32_index.json) have been updated. Upgrade gcc and esptool_py. This includes the fix for [macOS 11 (Big Sur)](https://github.com/espressif/arduino-esp32/issues/4408). 

See also [SparkFun forum](https://forum.sparkfun.com/posting.php?mode=edit&f=182&p=225120).