### PR TITLE
SparkFun RedBoard Turbo: map Serial to SerialUSB

### DIFF
--- a/sparkfun/samd/variants/SparkFun_RedBoard_Turbo/variant.h
+++ b/sparkfun/samd/variants/SparkFun_RedBoard_Turbo/variant.h
@@ -223,5 +223,8 @@ extern Uart Serial1;
 #define SERIAL_PORT_HARDWARE        Serial1
 #define SERIAL_PORT_HARDWARE_OPEN   Serial1
 
+// map Serial to SerialUSB
+#define Serial                      SerialUSB
+
 #endif /* _VARIANT_ARDUINO_ZERO_ */
 


### PR DESCRIPTION
As per the discussions in #93, add a define to map `Serial` to `SerialUSB`.

This matches the behaviour of official Arduino boards with native USB, including:
 * [Arduino MKR Zero](https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrzero/variant.h#L209)
 * [Arduino Leonardo](https://github.com/arduino/ArduinoCore-avr/blob/master/variants/leonardo/pins_arduino.h#L389)